### PR TITLE
Add XLSX file format

### DIFF
--- a/xena_gdc_etl/xena_dataset.py
+++ b/xena_gdc_etl/xena_dataset.py
@@ -1254,16 +1254,19 @@ class GDCPhenoset(XenaDataset):
     _XENA_GDC_DTYPE = {
         'biospecimen': {
             'data_category': 'Biospecimen',
-            'data_format': 'BCR XML',
+            'data_format': ['BCR XML', 'XLSX'],
         },
-        'clinical': {'data_category': 'Clinical', 'data_format': 'BCR XML'},
+        'clinical': {
+            'data_category': 'Clinical',
+            'data_format': ['BCR XML', 'XLSX'],
+        },
         'raw_phenotype': {
             'data_category': ['Biospecimen', 'Clinical'],
-            'data_format': 'BCR XML',
+            'data_format': ['BCR XML', 'XLSX'],
         },
         'GDC_phenotype': {
             'data_category': ['Biospecimen', 'Clinical'],
-            'data_format': 'BCR XML',
+            'data_format': ['BCR XML', 'XLSX'],
         },
     }
     # To resovle overlapping between raw data and API data, remove columns

--- a/xena_gdc_etl/xena_dataset.py
+++ b/xena_gdc_etl/xena_dataset.py
@@ -163,6 +163,7 @@ def read_clinical(fileobj):
         if sheets[0] == "Clinical Data":
             return xl_file.parse(sheets[0], index_col=0)
         else:
+            print("Clincal Data not found, skipping this file ...")
             return pd.DataFrame()
     elif ext != '.xml':
         raise IOError('Unknown file type for clinical data: {}'.format(ext))

--- a/xena_gdc_etl/xena_dataset.py
+++ b/xena_gdc_etl/xena_dataset.py
@@ -158,7 +158,11 @@ def read_clinical(fileobj):
         filename = fileobj
     ext = os.path.splitext(filename)[1]
     if ext == '.xlsx':
-        return pd.read_excel(filename, sheet_name='Clinical Data', index_col=0)
+        xl_file = pd.ExcelFile(filename)
+        sheets = xl_file.sheet_names
+        if sheets[0] == "Data Elements":
+            return pd.DataFrame()
+        return xl_file.parse(sheets[0], index_col=0)
     elif ext != '.xml':
         raise IOError('Unknown file type for clinical data: {}'.format(ext))
 
@@ -1523,7 +1527,8 @@ class GDCPhenoset(XenaDataset):
             # `read_biospecimen` and `read_clinical` will check file format
             try:
                 df = read_clinical(path)
-                clin_dfs.append(df)
+                if not df.empty:
+                    clin_dfs.append(df)
             except Exception:
                 try:
                     df = read_biospecimen(path)

--- a/xena_gdc_etl/xena_dataset.py
+++ b/xena_gdc_etl/xena_dataset.py
@@ -160,9 +160,10 @@ def read_clinical(fileobj):
     if ext == '.xlsx':
         xl_file = pd.ExcelFile(filename)
         sheets = xl_file.sheet_names
-        if sheets[0] == "Data Elements":
+        if sheets[0] == "Clinical Data":
+            return xl_file.parse(sheets[0], index_col=0)
+        else:
             return pd.DataFrame()
-        return xl_file.parse(sheets[0], index_col=0)
     elif ext != '.xml':
         raise IOError('Unknown file type for clinical data: {}'.format(ext))
 


### PR DESCRIPTION
https://github.com/ucscXena/xena-GDC-ETL/blob/58873ce30a57fd5a0a237311c419d4ba06774592/xena_gdc_etl/xena_dataset.py#L160-L161

`clinical` data now having some different sheet name other than `Clinical Data`, so I was getting errors. For example:
- `WT Data` in [Clinical.9c8108fd-c55e-46f8-ac13-9a2d9fbd1a6e.xlsx](https://github.com/ucscXena/xena-GDC-ETL/files/3354392/Clinical.9c8108fd-c55e-46f8-ac13-9a2d9fbd1a6e.xlsx) [TARGET-WT] 
- `Sample Submission` in 
[Clinical.f16dfbd6-132c-4d37-80af-357f721a1cea.xlsx](https://github.com/ucscXena/xena-GDC-ETL/files/3354413/Clinical.f16dfbd6-132c-4d37-80af-357f721a1cea.xlsx) [TARGET-AML]
- `Data Element` in 
[Clinical.74e823e2-5ffb-43ec-824c-364030dee4dc.xlsx](https://github.com/ucscXena/xena-GDC-ETL/files/3354452/Clinical.74e823e2-5ffb-43ec-824c-364030dee4dc.xlsx) [TARGET-AML] (this one is possibly not required).





